### PR TITLE
Minor adjustments for OSPF based underlay instantiation, and non-default OSPF process id

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@ ansible
 ansible-pylibssh
 paramiko
 pyats
+# This installs Genie plus additional parsing and testing libraries (like genie.libs.parser, genie.libs.sdk, etc.)
+pyats[library]
 genie

--- a/templates/isis_underlay.j2
+++ b/templates/isis_underlay.j2
@@ -24,14 +24,14 @@ Default ISIS network type in underlay is P2P for speeding up the convergence tim
         advertise passive-only
         metric-style wide
         log-adjacency-changes
-{% endif %}
 
-{# configure ISIS under interface and set ISIS interface P2P if not loopback #}
-{% for interface in interfaces%}
-    !
-    interface  {{ interface }}
-    {% if interfaces[interface].loopback == 'no'%}
-        ip router isis {{process_id}}
-        isis network point-to-point
-    {% endif %}
-{% endfor %}
+    {# configure ISIS under interface and set ISIS interface P2P if not loopback #}
+    {% for interface in interfaces%}
+        !
+        interface  {{ interface }}
+        {% if interfaces[interface].loopback == 'no'%}
+            ip router isis {{process_id}}
+            isis network point-to-point
+        {% endif %}
+    {% endfor %}
+{% endif %}

--- a/templates/ospf_interfaces.j2
+++ b/templates/ospf_interfaces.j2
@@ -8,19 +8,19 @@ Default OSPF network type in underlay is P2P for speeding up the convergence tim
 {# check if OSPF process is defined in the config for the Leaf/Spine #}
 {% if ospf is defined %}
 
-    {% set process_id = ospf.process_id | default ('1') %}
-    {# configure ospf under interface and set ospf interface P2P if not loopback #}
-    {% for interface in interfaces%}
-        !
-        interface  {{ interface }}
-        {% if interfaces[interface].loopback == 'no'%}
-            ip ospf network point-to-point
-        {% endif %}
-        ip ospf 1 area 0
-    {% endfor %}
-
-    {# configure ospf process and ospf router-id #}
+{% set process_id = ospf.process_id | default ('1') %}
+{# configure ospf under interface and set ospf interface P2P if not loopback #}
+{% for interface in interfaces %}
     !
-    router ospf {{ ospf.process_id }}
-        router-id {{ ospf.router_id }}
+    interface  {{ interface }}
+    {% if interfaces[interface].loopback == 'no' %}
+        ip ospf network point-to-point
+    {% endif %}
+    ip ospf {{ process_id }} area 0
+{% endfor %}
+
+{# configure ospf process and ospf router-id #}
+!
+router ospf {{ process_id }}
+    router-id {{ ospf.router_id }}
 {% endif %}


### PR DESCRIPTION
Fixes  "the task includes an option with an undefined variable.. 'process_id' is undefined" error message seen when instantiating OSPF process instead of ISIS. Also allows for non-default OSPF process_id.